### PR TITLE
Rectify typographical inaccuracies

### DIFF
--- a/backends/concrete-cpu/implementation/README.md
+++ b/backends/concrete-cpu/implementation/README.md
@@ -12,7 +12,7 @@ The `concrete-cpu` project is implemented thanks Rust, thus as the main prerequi
 
 ### Setting RUSTFLAGS
 
-As mentionned before the `concrete-cpu` project aims to use moderns CPU features, to be sure to activate all that is available in your machine you can export the following rust flags:
+As mentioned before the `concrete-cpu` project aims to use moderns CPU features, to be sure to activate all that is available in your machine you can export the following rust flags:
 
 ```
 export RUSTFLAGS="-C target-cpu=native"

--- a/backends/concrete-cpu/implementation/src/implementation/convert/mod.rs
+++ b/backends/concrete-cpu/implementation/src/implementation/convert/mod.rs
@@ -144,7 +144,7 @@ impl FftView<'_> {
     ///
     /// # Postconditions
     ///
-    /// this function leaves all the elements of `fourier` in an initialized state.
+    /// This function leaves all the elements of `fourier` in an initialized state.
     ///
     /// # Panics
     ///
@@ -164,7 +164,7 @@ impl FftView<'_> {
     ///
     /// # Postconditions
     ///
-    /// this function leaves all the elements of `fourier` in an initialized state.
+    /// This function leaves all the elements of `fourier` in an initialized state.
     ///
     /// # Panics
     ///
@@ -184,7 +184,7 @@ impl FftView<'_> {
     ///
     /// # Postconditions
     ///
-    /// this function leaves all the elements of `standard` in an initialized state.
+    /// This function leaves all the elements of `standard` in an initialized state.
     ///
     /// # Panics
     ///

--- a/backends/concrete-cpu/implementation/src/implementation/wop.rs
+++ b/backends/concrete-cpu/implementation/src/implementation/wop.rs
@@ -247,7 +247,7 @@ pub fn circuit_bootstrap_boolean(
         fourier_bsk_output_lwe_dimension,
     );
 
-    // Output for every pfksk that that come from the output GGSW
+    // Output for every pfksk that come from the output GGSW
     let mut out_pfksk_buffer_iter = ggsw_out
         .into_data()
         .chunks_exact_mut((glwe_params.dimension + 1) * glwe_params.polynomial_size)

--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -120,7 +120,7 @@ def compute_ops_per_dollar(data_point, product_hourly_cost):
     Compute numbers of operations per dollar for a given ``data_point``.
 
     :param data_point: timing value measured during benchmark in nanoseconds
-    :param product_hourly_cost: cost in dollar per hour of hardware used
+    :param product_hourly_cost: cost in dollars per hour of hardware used
 
     :return: number of operations per dollar
     """

--- a/compilers/concrete-compiler/compiler/include/concretelang-c/Support/CompilerEngine.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang-c/Support/CompilerEngine.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /// The CAPI should be really careful about memory allocation. Every pointer
-/// returned should points to a new buffer allocated for the purpose of the
+/// returned should point to a new buffer allocated for the purpose of the
 /// CAPI, and should have a respective destructor function.
 
 /// Opaque type declarations. Inspired from

--- a/compilers/concrete-compiler/compiler/include/concretelang/CAPI/Wrappers.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/CAPI/Wrappers.h
@@ -11,7 +11,7 @@
 #include "concretelang/Support/LibrarySupport.h"
 
 /// Add a mechanism to go from Cpp objects to C-struct, with the ability to
-/// represent errors. Also the other way arround.
+/// represent errors. Also the other way around.
 #define DEFINE_C_API_PTR_METHODS_WITH_ERROR(name, cpptype)                     \
   static inline name wrap(cpptype *cpp) { return name{cpp, (char *)NULL}; }    \
   static inline name wrap(cpptype *cpp, std::string errorStr) {                \

--- a/compilers/concrete-compiler/compiler/include/concretelang/ClientLib/CRT.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/ClientLib/CRT.h
@@ -19,7 +19,7 @@ namespace crt {
 /// \returns The product of moduli
 uint64_t productOfModuli(std::vector<int64_t> moduli);
 
-/// Compute the crt decomposition of a `val` according the given `moduli`.
+/// Compute the crt decomposition of a `val` according to the given `moduli`.
 ///
 /// \param moduli The moduli to compute the decomposition.
 /// \param val The value to decompose.

--- a/compilers/concrete-compiler/compiler/include/concretelang/ClientLib/EncryptedArguments.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/ClientLib/EncryptedArguments.h
@@ -121,7 +121,7 @@ public:
 
   // Generalize by computing shape by template recursion
 
-  /// Set a argument at the given pos as a 1D tensor of T.
+  /// Set an argument at the given pos as a 1D tensor of T.
   template <typename T>
   outcome::checked<void, StringError> pushArg(T *data, int64_t dim1,
                                               KeySet &keySet) {

--- a/compilers/concrete-compiler/compiler/include/concretelang/ClientLib/EvaluationKeys.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/ClientLib/EvaluationKeys.h
@@ -90,7 +90,7 @@ public:
                   KeyswitchKeyParam parameters)
       : _buffer(buffer), _parameters(parameters){};
 
-  /// @brief Returns the buffer that hold the keyswitch key.
+  /// @brief Returns the buffer that holds the keyswitch key.
   const uint64_t *buffer() const { return _buffer->data(); }
   size_t size() const { return _buffer->size(); }
 


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.